### PR TITLE
fix: add missing dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 networkx>=2.8.0
 matplotlib>=3.5.0
 pytest>=7.0.0
+tqdm>=4.67.0


### PR DESCRIPTION
Fix for:

```
python main.py
Traceback (most recent call last):
  File "/Users/samm/git/kereva-scanner/main.py", line 6, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```